### PR TITLE
Added console.error to uninstallation routine

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ console.log({ x: 1, y: 'prop' });
 console.error('Something bad happened :(');
 ```
 
-#### Restoring native `console.log`:
+#### Restoring native `console.log` and `console.error`:
 
 ```javascript
 require('better-log').uninstall();

--- a/index.js
+++ b/index.js
@@ -58,7 +58,8 @@ betterLog.install = function (newConfig) {
 };
 
 betterLog.uninstall = function () {
-	return console.log = log;
+        console.error = error; 
+        return console.log = log;
 };
 
 module.exports = betterLog;


### PR DESCRIPTION
If `install()` installs `betterError`, `uninstall()` should uninstall it. This PR implements that.

Tests work as expected.

Cheers
